### PR TITLE
Add devcontainer for cross platform builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,70 @@
+FROM ubuntu:22.04
+
+# Install build dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    cmake \
+    make \
+    git \
+    curl \
+    ca-certificates \
+    xz-utils \
+    sudo \
+    g++ \
+    gcc \
+    qemu-user-static \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download and install ARM GNU toolchain for Raspberry Pi 4
+# Detect architecture and download appropriate toolchain
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        TOOLCHAIN_URL="https://armkeil.blob.core.windows.net/developer/files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-aarch64-aarch64-none-linux-gnu.tar.xz"; \
+    else \
+        TOOLCHAIN_URL="https://armkeil.blob.core.windows.net/developer/files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz"; \
+    fi && \
+    curl -L "$TOOLCHAIN_URL" -o /tmp/arm-toolchain.tar.xz && \
+    mkdir -p /opt/arm-toolchain && \
+    tar -xf /tmp/arm-toolchain.tar.xz -C /opt/arm-toolchain --strip-components=1 && \
+    rm /tmp/arm-toolchain.tar.xz
+
+# Add toolchain to PATH
+ENV PATH="/opt/arm-toolchain/bin:${PATH}"
+
+# Create a non-root user
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Create CMake toolchain file for ARM64 cross-compilation (Raspberry Pi 4)
+RUN echo 'set(CMAKE_SYSTEM_NAME Linux)\n\
+set(CMAKE_SYSTEM_PROCESSOR aarch64)\n\
+\n\
+set(CMAKE_C_COMPILER aarch64-none-linux-gnu-gcc)\n\
+set(CMAKE_CXX_COMPILER aarch64-none-linux-gnu-g++)\n\
+\n\
+# Optimize for Raspberry Pi 4 (Cortex-A72)\n\
+set(CMAKE_C_FLAGS_INIT "-mcpu=cortex-a72 -mtune=cortex-a72")\n\
+set(CMAKE_CXX_FLAGS_INIT "-mcpu=cortex-a72 -mtune=cortex-a72")\n\
+\n\
+# Static link all libraries for tests (to run with QEMU)\n\
+# For production builds on the target, remove -static flag\n\
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-static")\n\
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-static-libstdc++ -static-libgcc")\n\
+\n\
+set(CMAKE_FIND_ROOT_PATH /opt/arm-toolchain/aarch64-none-linux-gnu)\n\
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\n\
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)\n\
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)\n\
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)\n\
+\n\
+# Use QEMU for running cross-compiled tests\n\
+set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/qemu-aarch64-static)\n' > /opt/toolchain-aarch64.cmake
+
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Z80 C++ ARM64 Cross-Compilation",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools",
+        "twxs.cmake"
+      ],
+      "settings": {
+        "cmake.configureArgs": [
+          "-DCMAKE_TOOLCHAIN_FILE=/opt/toolchain-aarch64.cmake"
+        ]
+      }
+    }
+  },
+  "postCreateCommand": "sudo bash -c 'echo \"#!/bin/bash\" > /usr/local/bin/cmake-rpi && echo \"cmake -DCMAKE_TOOLCHAIN_FILE=/opt/toolchain-aarch64.cmake \\\"\\$@\\\"\" >> /usr/local/bin/cmake-rpi && chmod +x /usr/local/bin/cmake-rpi' && echo 'ARM64 cross-compilation environment ready. Use: cmake-rpi .. (or cmake -DCMAKE_TOOLCHAIN_FILE=/opt/toolchain-aarch64.cmake ..)'",
+  "remoteUser": "vscode"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #   cmake -G Xcode ..
 #
 
-cmake_minimum_required (VERSION 3.25.1)
+cmake_minimum_required (VERSION 3.22.1)
 project (z80cpp)
 
 # Set the rpath policy and C++ version
@@ -37,7 +37,8 @@ set_target_properties (z80cpp-static PROPERTIES OUTPUT_NAME z80cpp)
 add_library(z80cpp::z80cpp-static ALIAS z80cpp-static)
 
 if (NOT DEFINED Z80CPP_STATIC_ONLY)
-    add_library (z80cpp SHARED ${z80cpp_sources})
+    add_library (z80cpp SHARED ${z80cpp_sources}
+            .devcontainer/Dockerfile)
 # Affects Win32 only: avoid dynamic/static *.lib files naming conflict 
     set_target_properties (z80cpp-static PROPERTIES PREFIX "lib")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,7 @@ set_target_properties (z80cpp-static PROPERTIES OUTPUT_NAME z80cpp)
 add_library(z80cpp::z80cpp-static ALIAS z80cpp-static)
 
 if (NOT DEFINED Z80CPP_STATIC_ONLY)
-    add_library (z80cpp SHARED ${z80cpp_sources}
-            .devcontainer/Dockerfile)
+    add_library (z80cpp SHARED ${z80cpp_sources})
 # Affects Win32 only: avoid dynamic/static *.lib files naming conflict 
     set_target_properties (z80cpp-static PROPERTIES PREFIX "lib")
 endif ()

--- a/README.md
+++ b/README.md
@@ -12,9 +12,31 @@ cmake ..
 make
 ```
 
+### Building with Devcontainer
+
+The project includes a devcontainer for cross-platform development and Raspberry Pi cross-compilation.
+
+**For native x86_64 builds:**
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+**For ARM cross-compilation (Raspberry Pi 4):**
+```bash
+mkdir build-rpi
+cd build-rpi
+cmake -DCMAKE_TOOLCHAIN_FILE=/opt/toolchain-aarch64.cmake ..
+make
+```
+
+Note: After modifying the Dockerfile, rebuild the devcontainer for changes to take effect.
+
 Run tests with `make test` from the build directory. All test output is shown by default.
 
-The core have the same features of [Z80Core](https://github.com/jsanchezv/Z80Core):
+The core has the same features as [Z80Core](https://github.com/jsanchezv/Z80Core):
 
 * Complete instruction set emulation
 * Emulates the undocumented bits 3 & 5 from flags register

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -483,7 +483,7 @@ void Z80::or_(uint8_t oper8) {
 
 // Operación de comparación con el registro A
 // es como SUB, pero solo afecta a los flags
-//  SIGN y ZERO se calculan a partir del resultado
+// Los flags SIGN y ZERO se calculan a partir del resultado
 // Los flags 3 y 5 se copian desde el operando (¡sigh!)
 void Z80::cp(uint8_t oper8) {
     auto res = static_cast<int16_t>(regA - oper8);

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -483,8 +483,8 @@ void Z80::or_(uint8_t oper8) {
 
 // Operación de comparación con el registro A
 // es como SUB, pero solo afecta a los flags
-// Los flags SIGN y ZERO se calculan a partir del resultado
-// Los flags 3 y 5 se copian desde el operando (sigh!)
+//  SIGN y ZERO se calculan a partir del resultado
+// Los flags 3 y 5 se copian desde el operando (¡sigh!)
 void Z80::cp(uint8_t oper8) {
     auto res = static_cast<int16_t>(regA - oper8);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.25.1)
+cmake_minimum_required (VERSION 3.22.1)
 
 add_executable(z80_sim_test
     z80_sim_test.cpp


### PR DESCRIPTION
Add devcontainer support for cross-platform development and ARM64 cross-compilation targeting Raspberry Pi 4.
Also lower the required CMake version to support older environments and includes minor comment updates.

Changes:

- Added devcontainer configuration with Dockerfile for ARM64 cross-compilation environment
- Lowered CMake minimum version requirement from 3.25.1 to 3.22.1
- Updated documentation with devcontainer build instructions
- Minor comment refinements in z80.cpp
